### PR TITLE
Fix decrement button store state setter in Solid counter

### DIFF
--- a/solid-mod-fed/src/Counter.tsx
+++ b/solid-mod-fed/src/Counter.tsx
@@ -25,7 +25,7 @@ export default function Counter() {
           Increment
         </button>
         <button
-          onClick={() => store.setState((c) => c + 1)}
+          onClick={() => store.setState((c) => c - 1)}
           style={styles.decrementButton}
           onMouseDown={(e) => (e.currentTarget.style.transform = "scale(0.95)")}
           onMouseUp={(e) => (e.currentTarget.style.transform = "scale(1)")}


### PR DESCRIPTION
I noticed in the video that you accidentally didn't update the decrement function to subtract by 1 instead of adding 1.

This fixes that. 🙂

Great video though, keep them coming!